### PR TITLE
ocid, basic, guild, stat API 추가

### DIFF
--- a/src/app/_utils/fetch/getBasic.ts
+++ b/src/app/_utils/fetch/getBasic.ts
@@ -1,0 +1,16 @@
+import { CharacterBasic } from "@/app/_type/type";
+
+export const getBasic = async (ocid: string) => {
+  const response = await fetch(
+    `api/getCharacterBasic?ocid=${encodeURIComponent(ocid)}`,
+  );
+
+  if (!response.ok) {
+    const err = await response.json();
+    throw new Error(err);
+  }
+
+  const data: CharacterBasic = await response.json();
+
+  return data;
+};

--- a/src/app/_utils/fetch/getGuild.ts
+++ b/src/app/_utils/fetch/getGuild.ts
@@ -1,0 +1,11 @@
+import { Guild } from "@/app/_type/type";
+
+export const getGuild = async (ocid: string) => {
+  const response = await fetch(
+    `api/getCharacterGuild?ocid=${encodeURIComponent(ocid)}`,
+  );
+
+  const data: Guild = await response.json();
+
+  return data;
+};

--- a/src/app/_utils/fetch/getOcid.ts
+++ b/src/app/_utils/fetch/getOcid.ts
@@ -1,0 +1,25 @@
+import { findOcidByName, setOcidListToLocalStorage } from "../localStorage";
+
+export const getOcid = async (characterName: string) => {
+  let ocid = findOcidByName(characterName);
+
+  if (!ocid) {
+    const response = await fetch(
+      `api/getCharacterOcid?character_name=${encodeURIComponent(characterName)}`,
+      {
+        method: "GET",
+        cache: "no-store",
+      },
+    );
+
+    if (!response.ok) {
+      const err = await response.json();
+      throw new Error(err);
+    }
+
+    const data: { ocid: string } = await response.json();
+    ocid = setOcidListToLocalStorage(characterName, data);
+  }
+
+  return ocid;
+};

--- a/src/app/_utils/fetch/getStats.ts
+++ b/src/app/_utils/fetch/getStats.ts
@@ -1,0 +1,16 @@
+import { FetchStats } from "@/app/_type/type";
+
+export const getStats = async (ocid: string) => {
+  const response = await fetch(
+    `api/getCharacterStat?ocid=${encodeURIComponent(ocid)}`,
+  );
+
+  if (!response.ok) {
+    const err = await response.json();
+    throw new Error(err);
+  }
+
+  const data: FetchStats = await response.json();
+
+  return data;
+};

--- a/src/app/_utils/getSearchParamsValue.ts
+++ b/src/app/_utils/getSearchParamsValue.ts
@@ -1,0 +1,9 @@
+export const getSearchParamsValue = (
+  request: { url: string | URL; base?: string | URL },
+  keyName: string,
+) => {
+  const { searchParams } = new URL(request.url);
+  const searchParamsValue = searchParams.get(keyName);
+
+  return searchParamsValue;
+};

--- a/src/app/_utils/localStorage.ts
+++ b/src/app/_utils/localStorage.ts
@@ -1,0 +1,79 @@
+import { LOCALSTORAGE_KEY } from "../_components/_constant/localstorage";
+import { MergedCharacter } from "../_type/type";
+
+interface OcidData {
+  name: string;
+  ocid: string;
+}
+
+export const getLocalStorageItems = <T>(key: string): T | null => {
+  const storageItem = localStorage.getItem(key);
+
+  if (!storageItem) return null;
+
+  try {
+    return JSON.parse(storageItem) as T;
+  } catch (e) {
+    return null;
+  }
+};
+
+export const setLocalStorageItems = <T extends { name: string }>(
+  key: string,
+  data: T,
+) => {
+  const storageItemList = getLocalStorageItems<T[]>(key);
+
+  const updatedItemList = storageItemList ? [...storageItemList] : [];
+
+  const index = updatedItemList.findIndex((item) => item.name === data.name);
+
+  if (index !== -1) {
+    updatedItemList[index] = data;
+  } else {
+    updatedItemList.push(data);
+  }
+
+  localStorage.setItem(key, JSON.stringify(updatedItemList));
+};
+
+/**
+ * 주어진 이름으로 로컬스토리지에서 ocid를 찾습니다.
+ *
+ * @param name - 검색할 캐릭터의 이름
+ * @returns 해당 이름을 가진 아이템이 존재하면 ocid를 반환하고, 그렇지 않으면 `null`을 반환합니다.
+ *
+ */
+export const findOcidByName = (name: string) => {
+  const ocidList = getLocalStorageItems<OcidData[]>(LOCALSTORAGE_KEY.ocidList);
+
+  if (!ocidList) return null;
+
+  const index = ocidList && ocidList.findIndex((item) => item.name === name);
+
+  return index !== -1 ? ocidList[index].ocid : null;
+};
+
+/**
+ *  캐릭터의 이름과 ocid를 객체로 묶어 로컬스토리지에 저장합니다.
+ *
+ * @param name - 추가할 캐릭터의 이름
+ * @param ocidObj - ocidObj : {ocid : "캐릭터의 ocid...."}
+ * @returns ocid
+ */
+export const setOcidListToLocalStorage = (
+  name: string,
+  ocidObj: { ocid: string },
+) => {
+  const ocid = ocidObj.ocid;
+
+  setLocalStorageItems(LOCALSTORAGE_KEY.ocidList, { name, ocid });
+
+  return ocid;
+};
+
+export const setCharacterInfoToLocalStorage = (userData: MergedCharacter) => {
+  setLocalStorageItems(LOCALSTORAGE_KEY.characterInfoList, userData);
+
+  return;
+};

--- a/src/app/api/getCharacterBasic/route.ts
+++ b/src/app/api/getCharacterBasic/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+import { getSearchParamsValue } from "@/app/_utils/getSearchParamsValue";
+import { SEARCH_PARAMS_KEY } from "@/app/_constant/searchParamsKey";
+import { CharacterBasic } from "@/app/_type/type";
+
+export async function GET(request: Request) {
+  const ocid = getSearchParamsValue(request, SEARCH_PARAMS_KEY.ocid);
+
+  if (!ocid) {
+    return NextResponse.json({ error: "ocid가 없습니다." }, { status: 400 });
+  }
+
+  try {
+    const apiKey = process.env.NEXT_PUBLIC_API_KEY as string;
+    const response = await fetch(
+      `https://open.api.nexon.com/heroes/v1/character/basic?ocid=${ocid}`,
+      {
+        method: "GET",
+        headers: {
+          "x-nxopen-api-key": apiKey,
+        },
+      },
+    );
+
+    const data: CharacterBasic = await response.json();
+
+    return NextResponse.json(data);
+  } catch (e) {}
+}

--- a/src/app/api/getCharacterGuild/route.ts
+++ b/src/app/api/getCharacterGuild/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+import { getSearchParamsValue } from "@/app/_utils/getSearchParamsValue";
+import { SEARCH_PARAMS_KEY } from "@/app/_constant/searchParamsKey";
+import { Guild } from "@/app/_type/type";
+
+export async function GET(request: Request) {
+  const ocid = getSearchParamsValue(request, SEARCH_PARAMS_KEY.ocid);
+
+  if (!ocid) {
+    return NextResponse.json({ error: "ocid가 없습니다." }, { status: 400 });
+  }
+
+  try {
+    const apiKey = process.env.NEXT_PUBLIC_API_KEY as string;
+    const response = await fetch(
+      `https://open.api.nexon.com/heroes/v1/character/guild?ocid=${ocid}`,
+      {
+        method: "GET",
+        headers: {
+          "x-nxopen-api-key": apiKey,
+        },
+      },
+    );
+
+    const data: Guild = await response.json();
+
+    return NextResponse.json(data);
+  } catch (e) {}
+}

--- a/src/app/api/getCharacterOcid/route.ts
+++ b/src/app/api/getCharacterOcid/route.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from "next/server";
 
+import { getSearchParamsValue } from "@/app/_utils/getSearchParamsValue";
+import { SEARCH_PARAMS_KEY } from "@/app/_constant/searchParamsKey";
+
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const characterName = searchParams.get("character_name");
+  const characterName = getSearchParamsValue(
+    request,
+    SEARCH_PARAMS_KEY.character_name,
+  );
 
   try {
     const apiKey = process.env.NEXT_PUBLIC_API_KEY as string;

--- a/src/app/api/getCharacterOcid/route.ts
+++ b/src/app/api/getCharacterOcid/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const characterName = searchParams.get("character_name");
+
+  try {
+    const apiKey = process.env.NEXT_PUBLIC_API_KEY as string;
+    const response = await fetch(
+      `https://open.api.nexon.com/heroes/v1/id?character_name=${characterName}`,
+      {
+        method: "GET",
+        headers: {
+          "x-nxopen-api-key": apiKey,
+        },
+      },
+    );
+
+    const data = await response.json();
+
+    if (!data.error) {
+      return NextResponse.json(data);
+    } else {
+      return NextResponse.json({ error: data.error }, { status: 400 });
+    }
+  } catch (e) {
+    console.error(e);
+  }
+}

--- a/src/app/api/getCharacterStat/route.ts
+++ b/src/app/api/getCharacterStat/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+import { getSearchParamsValue } from "@/app/_utils/getSearchParamsValue";
+import { SEARCH_PARAMS_KEY } from "@/app/_constant/searchParamsKey";
+import { CharacterStat } from "@/app/_type/type";
+
+export async function GET(request: Request) {
+  const ocid = getSearchParamsValue(request, SEARCH_PARAMS_KEY.ocid);
+
+  if (!ocid) {
+    return NextResponse.json({ error: "ocid가 없습니다." }, { status: 400 });
+  }
+
+  try {
+    const apiKey = process.env.NEXT_PUBLIC_API_KEY as string;
+    const response = await fetch(
+      `https://open.api.nexon.com/heroes/v1/character/stat?ocid=${ocid}`,
+      {
+        method: "GET",
+        headers: {
+          "x-nxopen-api-key": apiKey,
+        },
+      },
+    );
+
+    const data: CharacterStat = await response.json();
+
+    return NextResponse.json(data);
+  } catch (e) {}
+}


### PR DESCRIPTION
# 1. ocid, basic, guild, stat API 추가

## 닉네임으로 ocid 조회 기능 추가(2660cf0072230189ff746509bfffdf11cf0c4fb2)
- 닉네임으로 ocid를 조회 합니다.
- 로컬 스토리지에 ocid 및 캐릭터의 데이터를 저장하는 함수가 포함되어있습니다.

## 기본 정보 조회 (04ee811301a23bb9eb39330252e1d7aa1c4fbcc5)
- ocid를 이용해 기본 정보를 조회합니다.

## 길드 조회 (b6f004a8d485d440392032bcd576eafb940acee1)
- ocid를 이용해 가입한 길드를 조회합니다.

## 능력치 조회 (b2683930a62b75ec7c082fec05328d49c2c94e83)
- ocid를 이용해 능력치를 조회합니다.

##  searchParamsValue 함수 추가 및 ocid 조회 route에 해당 함수 추가(9425d58a6eb547936f8b89c24a1bfcf94ae478b2)
- searchParamsValue 함수는 searchParams에서 key으로 value를 얻어 리턴합니다.

<hr/>

- Closes #12 #17 #19 #20 